### PR TITLE
Remove logging TEST

### DIFF
--- a/pageindicatorview/src/main/java/com/rd/PageIndicatorView.java
+++ b/pageindicatorview/src/main/java/com/rd/PageIndicatorView.java
@@ -614,12 +614,9 @@ public class PageIndicatorView extends View implements ViewPager.OnPageChangeLis
         if (interactiveAnimation && (position == selectingPosition || position == selectedPosition)) {
             paint.setColor(selectedColor);
             canvas.drawCircle(frameXCoordinate, y, radiusPx, paint);
-            Log.e("TEST", "INVALID " + frameXCoordinate);
-
         } else if (!interactiveAnimation && (position == selectedPosition || position == lastSelectedPosition)) {
             paint.setColor(selectedColor);
             canvas.drawCircle(frameXCoordinate, y, radiusPx, paint);
-            Log.e("TEST", String.valueOf(frameXCoordinate));
         }
     }
 


### PR DESCRIPTION
Each slide animation logs too much in the console:

```
E/TEST: 630
E/TEST: 630
E/TEST: 624
E/TEST: 624
E/TEST: 619
E/TEST: 619
E/TEST: 614
E/TEST: 614
E/TEST: 609
E/TEST: 609
E/TEST: 604
E/TEST: 604
E/TEST: 600
E/TEST: 600
E/TEST: 596
E/TEST: 596
E/TEST: 593
E/TEST: 593
E/TEST: 589
E/TEST: 589
E/TEST: 586
E/TEST: 586
E/TEST: 583
```
